### PR TITLE
fix: upgrade lru past RUSTSEC-2026-0002

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ async-trait = "0.1.56"
 uuid = { version = "1.1", features = ["v4"] }
 itoa = "1.0"
 bigdecimal = { version = "0.4.1", features = ["serde"] }
-lru = "0.14.0"
+lru = "0.16.3"


### PR DESCRIPTION
Upgrades lru from the affected 0.14 line to 0.16.3 or newer. RustSec marks versions 0.9.0 through 0.16.2 as unsound because IterMut violates Stacked Borrows (RUSTSEC-2026-0002); 0.16.3 is the first patched release. RBDC does not use IterMut, and its existing StatementCache API is source-compatible with lru 0.16. Tested with cargo test -p rbdc: 70 unit, integration, and doc tests passed.